### PR TITLE
fix: avoid ChainedAssignmentError on marketplace fillna

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -751,7 +751,7 @@ class Component(ComponentBase):
 
                         if mkp_col:
                             df[mkp_col] = df[mkp_col].replace(r'^\s*$', pd.NA, regex=True)
-                            df[mkp_col].fillna(file_primary_mkp if file_primary_mkp else 'Unallocated', inplace=True)
+                            df[mkp_col] = df[mkp_col].fillna(file_primary_mkp if file_primary_mkp else 'Unallocated')
 
                         # Identify split records by assigning an incrementing split_index (0, 1, 2...) to duplicate PKs across chunks.
                         base_pk_cols = ['settlement_id', 'order_id', 'sku', 'amount_type', 'amount_description', 'transaction_type']


### PR DESCRIPTION
## Summary
- Produkčný job `73975716` (verzia `3.0.35`) spadol s `ChainedAssignmentError` na [src/component.py:754](src/component.py#L754).
- Pandas 2.x Copy-on-Write neumožňuje `df[col].method(inplace=True)`, lebo `df[col]` vracia kópiu a inplace zmena by sa stratila.
- Fix: klasické priradenie `df[col] = df[col].fillna(...)`.

## Test plan
- [ ] Po merge a tagnutí `3.0.36` pustiť job v Keboole
- [ ] Overiť že log neobsahuje `ChainedAssignmentError`
- [ ] Overiť že `settlement_report.csv` má riadky a prejde do Storage